### PR TITLE
chore: Replace to `&bootloader` instead of `&sys_reset`

### DIFF
--- a/config/boards/shields/dp1000/dp1000.keymap
+++ b/config/boards/shields/dp1000/dp1000.keymap
@@ -48,13 +48,13 @@
         mod_layer {
 /* LAYER_MOD
  * ,-----------------.        ,----------------------.
- * | &airpods |   7  |        |   8  |   &sys_reset  |
+ * | &airpods |   7  |        |   8  |   &bootloader |
  * |----------+------|        |------+---------------|
  * |          |   4  |        |   5  |   6           |
  * `-----------------'        `----------------------'
-*/
+ */
                         bindings = <
-    &airpods      &kp N7       &kp N8     &sys_reset
+    &airpods      &kp N7       &kp N8     &bootloader
     &bt BT_CLR    &bt BT_PRV   &bt BT_NXT &trans
                 >;
         };


### PR DESCRIPTION
* `&sys_reset`
  * Reset the keyboard and re-run the firmware flashed to the device
* `&bootloader`
  * Reset the keyboard and put it into DFU mode

See also: https://zmk.dev/docs/behaviors/reset